### PR TITLE
scroll exactly the remaining of the last page

### DIFF
--- a/lisp/pdf-roll.el
+++ b/lisp/pdf-roll.el
@@ -287,7 +287,10 @@ If PIXELS is non-nil N is number of pixels instead of lines."
              (if (eq (point) (- (point-max) 3))
                  (prog1 nil
                    (setq n (min n (max 0 (- occupied-pixels (/ (window-text-height window t) 2)))))
-                   (message "End of buffer"))
+                   (when (and (nth 3 data) (< (nth 3 data) n))
+                     ;; scroll exactly the remaining of the last page
+                     (setq n (nth 3 data))
+                     (message "End of buffer")))
                (when (>= n occupied-pixels)
                  (cl-decf n occupied-pixels))))
       (forward-char 4))


### PR DESCRIPTION
Hi,

Currently, when `pdf-roll-mode` is enabled, the last page can be over-scrolled to half of the displayed window: the last page is displayed at the top-half, while the bottom-half of the window is empty.

I fixed this issue so that the last page is scrolled to fit exactly the window (when the page is zoomed bigger than a window).

Can you review and merge this PR?
Thanks! 